### PR TITLE
Load COLMAP masks

### DIFF
--- a/colmap.cpp
+++ b/colmap.cpp
@@ -112,10 +112,18 @@ InputData inputDataFromColmap(const std::string &projectRoot, const std::string&
             filePath += ch;
         }
 
+        fs::path imageDir;
         if (colmapImageSourcePath.empty())
-            cam.filePath = (fs::path(projectRoot) / "images" / filePath).string();
+            imageDir = fs::path(projectRoot) / "images";
         else
-            cam.filePath = (fs::path(colmapImageSourcePath) / filePath).string();
+            imageDir = fs::path(colmapImageSourcePath);
+
+        cam.filePath = (imageDir / filePath).string();
+
+        fs::path maskDir = imageDir.parent_path() / "masks";
+        fs::path mPath = maskDir / filePath;
+        if (fs::exists(mPath))
+            cam.maskPath = mPath.string();
 
         unorientedPoses[i].index_put_({Slice(None, 3), Slice(None, 3)}, Rinv);
         unorientedPoses[i].index_put_({Slice(None, 3), Slice(3, 4)}, Tinv);

--- a/input_data.cpp
+++ b/input_data.cpp
@@ -45,6 +45,10 @@ void Camera::loadImage(float downscaleFactor){
     std::cout << "Loading " << filePath << std::endl;
 
     cv::Mat cImg = imreadRGB(filePath);
+    cv::Mat cMask;
+    if (!maskPath.empty() && fs::exists(maskPath)){
+        cMask = cv::imread(maskPath, cv::IMREAD_GRAYSCALE);
+    }
     
     float rescaleF = 1.0f;
     // If camera intrinsics don't match the image dimensions 
@@ -55,6 +59,9 @@ void Camera::loadImage(float downscaleFactor){
     fy *= rescaleF;
     cx *= rescaleF;
     cy *= rescaleF;
+    if (!cMask.empty()){
+        cv::resize(cMask, cMask, cv::Size(), rescaleF, rescaleF, cv::INTER_NEAREST);
+    }
 
     if (downscaleFactor > 1.0f){
         float scaleFactor = 1.0f / downscaleFactor;
@@ -63,6 +70,9 @@ void Camera::loadImage(float downscaleFactor){
         fy *= scaleFactor;
         cx *= scaleFactor;
         cy *= scaleFactor;
+        if (!cMask.empty()){
+            cv::resize(cMask, cMask, cv::Size(), scaleFactor, scaleFactor, cv::INTER_NEAREST);
+        }
     }
 
     K = getIntrinsicsMatrix();
@@ -76,7 +86,13 @@ void Camera::loadImage(float downscaleFactor){
 
         cv::Mat undistorted = cv::Mat::zeros(cImg.rows, cImg.cols, cImg.type());
         cv::undistort(cImg, undistorted, cK, distCoeffs, newK);
-        
+
+        if (!cMask.empty()){
+            cv::Mat undistortedMask = cv::Mat::zeros(cMask.rows, cMask.cols, cMask.type());
+            cv::undistort(cMask, undistortedMask, cK, distCoeffs, newK);
+            cMask = undistortedMask;
+        }
+
         image = imageToTensor(undistorted);
         K = floatNxNMatToTensor(newK);
     }else{
@@ -86,6 +102,10 @@ void Camera::loadImage(float downscaleFactor){
 
     // Crop to ROI
     image = image.index({Slice(roi.y, roi.y + roi.height), Slice(roi.x, roi.x + roi.width), Slice()});
+    if (!cMask.empty()){
+        cMask = cMask(roi);
+        mask = torch::from_blob(cMask.data, {cMask.rows, cMask.cols}, torch::kU8).clone().to(torch::kFloat32) / 255.0f;
+    }
 
     // Update parameters
     height = image.size(0);
@@ -114,6 +134,30 @@ torch::Tensor Camera::getImage(int downscaleFactor){
         imagePyramids[downscaleFactor] = t;
         return t;
     }
+}
+
+torch::Tensor Camera::getMask(int downscaleFactor){
+    torch::Tensor baseMask;
+    if (mask.numel()){
+        baseMask = mask;
+    }else if (image.numel()){
+        baseMask = torch::ones({image.size(0), image.size(1)}, image.options().dtype(torch::kFloat32));
+    }else{
+        baseMask = torch::ones({height, width}, torch::TensorOptions().dtype(torch::kFloat32));
+    }
+
+    if (downscaleFactor <= 1) return baseMask;
+
+    if (maskPyramids.find(downscaleFactor) != maskPyramids.end()){
+        return maskPyramids[downscaleFactor];
+    }
+
+    auto opts = torch::nn::functional::InterpolateFuncOptions()
+                    .size(std::vector<long long>{baseMask.size(0) / downscaleFactor, baseMask.size(1) / downscaleFactor})
+                    .mode(torch::kNearest);
+    torch::Tensor resized = torch::nn::functional::interpolate(baseMask.unsqueeze(0).unsqueeze(0), opts).squeeze();
+    maskPyramids[downscaleFactor] = resized;
+    return resized;
 }
 
 bool Camera::hasDistortionParameters(){

--- a/input_data.hpp
+++ b/input_data.hpp
@@ -24,6 +24,7 @@ struct Camera{
     float p2 = 0;
     torch::Tensor camToWorld;
     std::string filePath = "";
+    std::string maskPath = "";
     CameraType cameraType = CameraType::Perspective;
 
     Camera(){};
@@ -37,12 +38,15 @@ struct Camera{
     bool hasDistortionParameters();
     std::vector<float> undistortionParameters();
     torch::Tensor getImage(int downscaleFactor);
+    torch::Tensor getMask(int downscaleFactor);
 
     void loadImage(float downscaleFactor);
     torch::Tensor K;
     torch::Tensor image;
+    torch::Tensor mask;
 
     std::unordered_map<int, torch::Tensor> imagePyramids;
+    std::unordered_map<int, torch::Tensor> maskPyramids;
 };
 
 struct Points{

--- a/model.hpp
+++ b/model.hpp
@@ -17,7 +17,7 @@ using namespace torch::autograd;
 torch::Tensor randomQuatTensor(long long n);
 torch::Tensor projectionMatrix(float zNear, float zFar, float fovX, float fovY, const torch::Device &device);
 torch::Tensor psnr(const torch::Tensor& rendered, const torch::Tensor& gt);
-torch::Tensor l1(const torch::Tensor& rendered, const torch::Tensor& gt);
+torch::Tensor l1(const torch::Tensor& rendered, const torch::Tensor& gt, const torch::Tensor& mask);
 
 struct Model{
   Model(const InputData &inputData, int numCameras,
@@ -74,7 +74,7 @@ struct Model{
   void saveSplat(const std::string &filename);
   void saveDebugPly(const std::string &filename, int step);
   int loadPly(const std::string &filename);
-  torch::Tensor mainLoss(torch::Tensor &rgb, torch::Tensor &gt, float ssimWeight);
+  torch::Tensor mainLoss(torch::Tensor &rgb, torch::Tensor &gt, float ssimWeight, const torch::Tensor& mask = torch::Tensor());
 
   void addToOptimizer(torch::optim::Adam *optimizer, const torch::Tensor &newParam, const torch::Tensor &idcs, int nSamples);
   void removeFromOptimizer(torch::optim::Adam *optimizer, const torch::Tensor &newParam, const torch::Tensor &deletedMask);

--- a/opensplat.cpp
+++ b/opensplat.cpp
@@ -150,8 +150,9 @@ int main(int argc, char *argv[]){
             torch::Tensor rgb = model.forward(cam, step);
             torch::Tensor gt = cam.getImage(model.getDownscaleFactor(step));
             gt = gt.to(device);
+            torch::Tensor mask = cam.getMask(model.getDownscaleFactor(step)).to(device);
 
-            torch::Tensor mainLoss = model.mainLoss(rgb, gt, ssimWeight);
+            torch::Tensor mainLoss = model.mainLoss(rgb, gt, ssimWeight, mask);
             mainLoss.backward();
             
             if (step % displayStep == 0) {
@@ -193,7 +194,8 @@ int main(int argc, char *argv[]){
         if (valCam != nullptr){
             torch::Tensor rgb = model.forward(*valCam, numIters);
             torch::Tensor gt = valCam->getImage(model.getDownscaleFactor(numIters)).to(device);
-            std::cout << valCam->filePath << " validation loss: " << model.mainLoss(rgb, gt, ssimWeight).item<float>() << std::endl; 
+            torch::Tensor mask = valCam->getMask(model.getDownscaleFactor(numIters)).to(device);
+            std::cout << valCam->filePath << " validation loss: " << model.mainLoss(rgb, gt, ssimWeight, mask).item<float>() << std::endl;
         }
     }catch(const std::exception &e){
         std::cerr << e.what() << std::endl;

--- a/ssim.cpp
+++ b/ssim.cpp
@@ -5,7 +5,7 @@
 
 using namespace torch::indexing;
 
-torch::Tensor SSIM::eval(const torch::Tensor& rendered, const torch::Tensor& gt) {
+torch::Tensor SSIM::eval(const torch::Tensor& rendered, const torch::Tensor& gt, const torch::Tensor& mask) {
     torch::Tensor img1 = gt.permute({2, 0, 1}).index({None, "..."});
     torch::Tensor img2 = rendered.permute({2, 0, 1}).index({None, "..."});
     
@@ -28,7 +28,9 @@ torch::Tensor SSIM::eval(const torch::Tensor& rendered, const torch::Tensor& gt)
 
     torch::Tensor ssimMap = ((2.0f * mu1mu2 + C1) * (2.0f * sigma12 + C2)) / ((mu1Sq + mu2Sq + C1) * (sigma1Sq + sigma2Sq + C2));
 
-    return ssimMap.mean();
+    torch::Tensor weight = mask.view({1, 1, mask.size(0), mask.size(1)});
+    torch::Tensor denom = weight.sum() * channel;
+    return (ssimMap * weight).sum() / (denom + 1e-8);
 }
 
 torch::Tensor SSIM::createWindow(){

--- a/ssim.hpp
+++ b/ssim.hpp
@@ -12,7 +12,7 @@ public:
         window = createWindow();
     };
 
-    torch::Tensor eval(const torch::Tensor& rendered, const torch::Tensor& gt);
+    torch::Tensor eval(const torch::Tensor& rendered, const torch::Tensor& gt, const torch::Tensor& mask);
 private:
     torch::Tensor createWindow();
     torch::Tensor gaussian(float sigma);


### PR DESCRIPTION
## Summary
- Detect mask images alongside COLMAP frames and record their paths
- Load grayscale masks with the same rescaling and undistortion as images

## Testing
- `cmake -S . -B build` *(fails: Could not find Torch package)*

------
https://chatgpt.com/codex/tasks/task_e_689ffb94f5288331b3ad8443336e7a1f